### PR TITLE
Use 0.* version of zfc-user-doctrine-orm

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
         "gedmo/doctrine-extensions": ">=v2.2.0",
         "monolog/monolog": "dev-master",
         "ewgo/solarium-module": "dev-master",
-        "zf-commons/zfc-user-doctrine-orm": "dev-master",
+        "zf-commons/zfc-user-doctrine-orm": "0.*",
         "bjyoungblood/bjy-authorize": "dev-master"
     },
     "autoload": {


### PR DESCRIPTION
Unfortunately zfc-user-doctrine-orm has no branch alias for `dev-master`. Because other package require `0.*`, I cannot install synergy-common. I made a pull request (https://github.com/ZF-Commons/ZfcUserDoctrineORM/pull/68), but as the last PR was closed 10 months ago, chances are high, that we have to wait longer.
Would be great, if you could change the dependency to `0.*` You would miss only an added Licence file: https://github.com/ZF-Commons/ZfcUserDoctrineORM/commits/master
